### PR TITLE
Update _hsts.conf template

### DIFF
--- a/backend/templates/_hsts.conf
+++ b/backend/templates/_hsts.conf
@@ -1,8 +1,8 @@
 {% if certificate and certificate_id > 0 -%}
 {% if ssl_forced == 1 or ssl_forced == true %}
 {% if hsts_enabled == 1 or hsts_enabled == true %}
-  # HSTS (ngx_http_headers_module is required) (31536000 seconds = 1 year)
-  add_header Strict-Transport-Security "max-age=31536000;{% if hsts_subdomains == 1 or hsts_subdomains == true -%} includeSubDomains;{% endif %} preload" always;
+  # HSTS (ngx_http_headers_module is required) (63072000 seconds = 2 years)
+  add_header Strict-Transport-Security "max-age=63072000;{% if hsts_subdomains == 1 or hsts_subdomains == true -%} includeSubDomains;{% endif %} preload" always;
 {% endif %}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
I propose change to default HSTS value - increase from 1 year to 2 years, as per [Mozilla TLS recommendations](https://wiki.mozilla.org/Security/Server_Side_TLS).
- Security hardening principle
- Recommended by Mozilla and general security whitepapers
- 1 year fails most SSL security tests

If variable value needed, I'd suggest an option in Host/SSL in WebGUI.

Thank you, keep up the great work.